### PR TITLE
Check for root/sudo access at beginning of script.

### DIFF
--- a/swap.sh
+++ b/swap.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+
 # Do argument checks
 if [ ! "$#" -ge 1 ]; then
     echo "Usage: $0 {size}"
@@ -9,11 +10,23 @@ if [ ! "$#" -ge 1 ]; then
     exit 1
 fi
 
+SUDO=''
+
+# Check if invoking user is root
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Root access is required, please run as root or enter sudo password if prompted." >&2
+    if sudo true; then
+        SUDO='sudo'
+    else
+        echo "Unable to run command as root. Please check your access and try again." >&2
+        exit 1
+    fi
+fi
+
 
 ## Intro
 echo "Welcome to Swap setup script! This script will automatically setup a swap file and enable it."
-echo "Root access is required, please run as root or enter sudo password." 
-echo "Source is @ https://github.com/Cretezy/Swap" 
+echo "Source is @ https://github.com/Cretezy/Swap"
 echo
 
 ## Setup variables
@@ -29,11 +42,11 @@ fi
 
 
 ## Run
-sudo fallocate -l $SWAP_SIZE $SWAP_PATH  # Allocate size
-sudo chmod 600 $SWAP_PATH                # Set proper permission
-sudo mkswap $SWAP_PATH                   # Setup swap         
-sudo swapon $SWAP_PATH                   # Enable swap
-echo "$SWAP_PATH   none    swap    sw    0   0" | sudo tee /etc/fstab -a # Add to fstab
+$SUDO fallocate -l $SWAP_SIZE $SWAP_PATH  # Allocate size
+$SUDO chmod 600 $SWAP_PATH                # Set proper permission
+$SUDO mkswap $SWAP_PATH                   # Setup swap
+$SUDO swapon $SWAP_PATH                   # Enable swap
+echo "$SWAP_PATH   none    swap    sw    0   0" | $SUDO tee /etc/fstab -a # Add to fstab
 
 ## Outro
 


### PR DESCRIPTION
Prevents trying to run multiple commands if the user doesn't have root/sudo access. As well, runs commands directly without invoking `sudo` if the user is already root.